### PR TITLE
 Portable Telegram config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://www.hetzner.com/sb
 usage: hah.py [-h] [--tax TAX] --price PRICE [--disk-count DISK_COUNT] --disk-size DISK_SIZE
               [--disk-quick] [--disk-ent] [--hw-raid] [--red-psu] [--cpu-count CPU_COUNT]
               --cpu-score CPU_SCORE --ram RAM [--ecc] [--dc DC] [-f [F]] [--test-mode]
+              [--tgm-config TGM_CONFIG]
 
 hah.py -- checks for newest servers on Hetzner server auction (server-bidding) and pushes them via telegram_send
 
@@ -38,6 +39,8 @@ optional arguments:
   --dc DC               datacenter (FSN1-DC15) or location (FSN)
   -f [F]                state file
   --test-mode           do not send actual messages and ignore state file
+  --tgm-config TGM_CONFIG
+                        file path to custom telegram configuration
 ```
 
 Example: `./hah.py --price 51 --disk-size 3000 --ram 24 --cpu-score 10000` - this will get servers cheaper than 51 EUR with more than 24GB of RAM, disks at least 3TB and CPU with score better than 10k.

--- a/hah.py
+++ b/hah.py
@@ -19,6 +19,7 @@ parser.add_argument('--ecc',        action='store_true',            help='requir
 parser.add_argument('--dc',         nargs=1,required=False,         help='datacenter (FSN1-DC15) or location (FSN)')
 parser.add_argument('-f',           nargs='?',                      help='state file')
 parser.add_argument('--test-mode',  action='store_true',            help='do not send actual messages and ignore state file')
+parser.add_argument('--tgm-config', nargs=1,required=False,         help='file path to custom telegram configuration')
 args = parser.parse_args()
 
 if not args.test_mode:
@@ -83,7 +84,11 @@ for server in servers:
 		print(msg)
 
 		if not args.test_mode:
-			telegram_send.send(messages=[msg], parse_mode="markdown")
+			if args.tgm_config:
+				telegram_send.send(messages=[msg], parse_mode="markdown", conf=args.tgm_config[0])
+			else:
+				telegram_send.send(messages=[msg], parse_mode="markdown")
+
 			f.write(","+str(server['key']))
 
 if not args.test_mode:


### PR DESCRIPTION
Add ability to supply a specific Telegram configuration file outside of the OS default paths. Useful for Docker containers where the configuration data is supplied by a secret.